### PR TITLE
chore: add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      groups:
+          npm-dependencies:
+              patterns:
+                  - '*'
+      open-pull-requests-limit: 5


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` so npm updates are **grouped into a single weekly PR** instead of one PR per package.

## Why
The repo had no Dependabot config, so security/version bumps arrived as one PR each (6 open at the time of writing). With a `groups` block matching `*`, routine version bumps collapse into one grouped PR — one CI run, one merge. Security-advisory PRs may still open individually when an advisory lands.

Since the generator ships its `package-lock.json` via `git clone` (nera-installer), keeping the lockfile current genuinely benefits fresh clones — this just makes maintaining it far less noisy.

No version bump: the generator isn't published to npm, and this is a CI/tooling-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)