### PR TITLE
chore: drop Node 18 support (floor to Node 20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # No cheerio here, so Node 18 is genuinely supported and
-                # matches the `engines` floor.
-                node-version: [18, 20, 22]
+                # Node 18 reached EOL 2025-04-30 and the toolchain
+                # (vitest 4 / vite 8 / eslint 10) requires Node 20+, so the
+                # floor is Node 20 to match the `engines` field.
+                node-version: [20, 22]
 
         steps:
             - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [4.4.0] - 2026-07-21
+
+### Changed
+
+-   minimum supported Node raised from 18 to 20; Node 18 reached
+    end-of-life on 2025-04-30 and the dev toolchain (vitest 4, vite 8,
+    eslint 10) requires Node 20+
+-   CI matrix now tests Node 20 and 22 (dropped 18)
+
+
 ## [4.3.0] - 2026-07-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nera",
-    "version": "4.3.0",
+    "version": "4.4.0",
     "description": "A simple static site generator",
     "main": "index.js",
     "scripts": {
@@ -28,7 +28,7 @@
     "author": "Michael Becker <micha.becker79@gmail.com> (https://github.com/seebaermichi)",
     "license": "MIT",
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## What
- `engines.node`: `>=18.0.0` → `>=20.0.0`
- CI matrix: `[18, 20, 22]` → `[20, 22]`
- version `4.3.0` → `4.4.0` + CHANGELOG entry

## Why
Node 18 reached end-of-life on 2025-04-30. The current dev toolchain — vitest 4, vite 8, eslint 10 (arriving via the grouped Dependabot PR #27) — requires Node 20+ (`node:util` `styleText`), which broke the Node 18 CI job. This makes Node 20 the supported floor, unblocking #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)